### PR TITLE
Fix crash in [NSManagedObjectContext rebuildAllContexts]

### DIFF
--- a/NLCoreData/NSManagedObjectContext+NLCoreData.m
+++ b/NLCoreData/NSManagedObjectContext+NLCoreData.m
@@ -108,9 +108,18 @@ undoEnabled;
 
 + (void)rebuildAllContexts
 {
-	*_mainContextTokenRef		= 0;
-	*_storeContextTokenRef		= 0;
-	*_backgroundContextTokenRef	= 0;
+    if (_mainContextTokenRef) {
+        *_mainContextTokenRef = 0;
+    }
+
+    if (_storeContextTokenRef) {
+        *_storeContextTokenRef = 0;
+    }
+
+    if (_backgroundContextTokenRef) {
+        *_backgroundContextTokenRef	= 0;
+    }
+
 	_mainContext				= nil;
 	_storeContext				= nil;
 	_backgroundContext			= nil;


### PR DESCRIPTION
_mainContextTokenRef
_storeContextTokenRef
_backgroundContextTokenRef

may be NULL if you haven't accessed

[NSManagedObjectContext mainContext]
[NSManagedObjectContext storeContext]
[NSManagedObjectContext backgroundContext]
