### PR TITLE
Add [NSFetchRequest sortByKey:ascending:selector:] method

### DIFF
--- a/NLCoreData/NSFetchRequest+NLCoreData.h
+++ b/NLCoreData/NSFetchRequest+NLCoreData.h
@@ -45,11 +45,20 @@
 
 /**
  @name Sorting
- Adds add a sort descriptor the fetch request. First added is primary, second added is secondary, etc.
+ Adds a sort descriptor to the fetch request. First added is primary, second added is secondary, etc.
  @param key The keypath to use when performing a comparison.
  @param ascending YES if the receiver specifies sorting in ascending order, otherwise NO.
  */
 - (void)sortByKey:(NSString *)key ascending:(BOOL)ascending;
+
+/**
+ @name Sorting
+ Adds a sort descriptor to the fetch request. First added is primary, second added is secondary, etc.
+ @param key The keypath to use when performing a comparison.
+ @param ascending YES if the receiver specifies sorting in ascending order, otherwise NO.
+ @param selector The selector to use when performing a comparison.
+ */
+- (void)sortByKey:(NSString *)key ascending:(BOOL)ascending selector:(SEL)selector;
 
 /**
  @name Predicate

--- a/NLCoreData/NSFetchRequest+NLCoreData.m
+++ b/NLCoreData/NSFetchRequest+NLCoreData.m
@@ -46,9 +46,14 @@ static BOOL _NLCoreDataNSFetchRequestIncludesSubentities = NO;
 
 - (void)sortByKey:(NSString *)key ascending:(BOOL)ascending
 {
-	NSSortDescriptor* sortDescriptor	= [NSSortDescriptor sortDescriptorWithKey:key ascending:ascending];
-	NSMutableArray* descriptors			= [NSMutableArray arrayWithArray:[self sortDescriptors]];
-	
+	[self sortByKey:key ascending:ascending selector:nil];
+}
+
+- (void)sortByKey:(NSString *)key ascending:(BOOL)ascending selector:(SEL)selector
+{
+	NSSortDescriptor* sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:key ascending:ascending selector:selector];
+	NSMutableArray* descriptors = [NSMutableArray arrayWithArray:[self sortDescriptors]];
+
 	[descriptors addObject:sortDescriptor];
 	[self setSortDescriptors:descriptors];
 }


### PR DESCRIPTION
I am proposing to add a [NSFetchRequest sortByKey:ascending:selector:] method,
which would make writing this kind of code more convenient:

NSSortDescriptor *descriptor = [NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES selector:@selector(localizedCompare:)];
request.sortDescriptors = @[descriptor];

new style:

[request sortByKey:@"name" ascending:YES selector:@selector(localizedCompare:)];
